### PR TITLE
Replace batch request schema with the official definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": "kzwang/node-git-lfs",
   "dependencies": {
-    "aws-sdk": "^2.2.10",
+    "aws-sdk": "^2.1111.0",
     "btoa": "^1.1.2",
     "co": "^4.6.0",
     "co-body": "^4.0.0",

--- a/schema/http-v1-batch-request-schema.json
+++ b/schema/http-v1-batch-request-schema.json
@@ -1,8 +1,14 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema",
-  "title": "Git LFS HTTPS Batch API v1 Request",
+  "title": "Git LFS HTTPS Batch API Request",
   "type": "object",
   "properties": {
+    "transfers": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "operation": {
       "type": "string"
     },
@@ -15,7 +21,11 @@
             "type": "string"
           },
           "size": {
-            "type": "number"
+            "type": "number",
+            "minimum": 0
+          },
+          "authenticated": {
+            "type": "boolean"
           }
         },
         "required": ["oid", "size"],
@@ -23,6 +33,5 @@
       }
     }
   },
-  "required": ["objects", "operation"],
-  "additionalProperties": false
+  "required": ["objects", "operation"]
 }


### PR DESCRIPTION
Updates the batch request schema with the official definition from `git-lfs`.

Schema from: https://github.com/git-lfs/git-lfs/blob/master/tq/schemas/http-batch-request-schema.json

Fixes kzwang/node-git-lfs#5